### PR TITLE
修复 contents 表为空时，checkField 报错

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -413,16 +413,21 @@ function checkField() {
     $prefix = $db->getPrefix();
 
     // 检查阅读量字段是否存在
-    if (!array_key_exists('views', $db->fetchRow($db->select()->from('table.contents')))) {
+    if (!columnExists($db, $prefix . 'contents', 'views')) {
         // 在文章表中创建一个字段用来存储阅读量
         $db->query('ALTER TABLE `' . $prefix . 'contents` ADD `views` INT(10) NOT NULL DEFAULT 0;');
     }
 
     // 检查点赞字段是否存在
-    if (!array_key_exists('agree', $db->fetchRow($db->select()->from('table.contents')))) {
+    if (!columnExists($db, $prefix . 'contents', 'agree')) {
         //  在文章表中创建一个字段用来存储点赞数量
         $db->query('ALTER TABLE `' . $prefix . 'contents` ADD `agree` INT(10) NOT NULL DEFAULT 0;');
     }
+}
+
+//判断字段是否存在
+function columnExists($db,$table,$column) {
+    return in_array($column, array_column($db->query('PRAGMA table_info(' . $table . ');')->fetchAll(), 1));
 }
 
 //  设置文章阅读量


### PR DESCRIPTION
## 触发条件

当数据库中 contents 表为空时，也即博客中无文章。

访问首页引发 functions.php 中 checkField 函数报错

`array_key_exists(): Argument #2 ($array) must be of type array, null given`

## 错误原因

由于 contents 表中没有数据。

functions.php 中 checkField 函数的判断字段是否存在语句。

`$db->fetchRow($db->select()->from('table.contents'))` 返回了一个 `null`。

`array_key_exists()` 函数的第二个参数接受 null 后报错。

## 解决方法

重写字段是否存在的判断逻辑。