### PR TITLE
将硬编码的 /admin/ 路径修改为 $this->options->adminUrl() 方法获取

### DIFF
--- a/components/post-list.php
+++ b/components/post-list.php
@@ -78,7 +78,7 @@ while ($this->next()):
                                 </div>
                                 <?php if ($this->user->hasLogin()): ?>
                                     <div class="d-none d-sm-block d-md-block d-lg-block d-xl-block">
-                                        <a href="<?php echo $this->options->siteUrl . 'admin/write-post.php?cid=' . $this->cid; ?>" class="float-right edit-link">
+                                        <a href="<?php echo $this->options->siteUrl . __TYPECHO_ADMIN_DIR__ . 'write-post.php?cid=' . $this->cid; ?>" class="float-right edit-link">
                                             <i class="icon-pencil mr-1"></i>
                                             <b><?php echo $GLOBALS['t']['post']['edit']; ?></b>
                                         </a>
@@ -114,7 +114,7 @@ while ($this->next()):
                             </div>
                             <?php if ($this->user->hasLogin()): ?>
                                 <div class="d-none d-sm-block d-md-block d-lg-block d-xl-block">
-                                    <a href="<?php echo $this->options->siteUrl . 'admin/write-post.php?cid=' . $this->cid; ?>" class="float-right edit-link">
+                                    <a href="<?php echo $this->options->siteUrl . __TYPECHO_ADMIN_DIR__ . 'write-post.php?cid=' . $this->cid; ?>" class="float-right edit-link">
                                         <i class="icon-pencil mr-1"></i>
                                         <b><?php echo $GLOBALS['t']['post']['edit']; ?></b>
                                     </a>
@@ -139,7 +139,7 @@ while ($this->next()):
                         </div>
                         <?php if ($this->user->hasLogin()): ?>
                             <div class="d-none d-sm-block d-md-block d-lg-block d-xl-block">
-                                <a href="<?php echo $this->options->siteUrl . 'admin/write-post.php?cid=' . $this->cid; ?>" class="float-right edit-link">
+                                <a href="<?php echo $this->options->siteUrl . __TYPECHO_ADMIN_DIR__ . 'write-post.php?cid=' . $this->cid; ?>" class="float-right edit-link">
                                     <i class="icon-pencil mr-1"></i>
                                     <b><?php echo $GLOBALS['t']['post']['edit']; ?></b>
                                 </a>

--- a/components/post-list.php
+++ b/components/post-list.php
@@ -78,7 +78,7 @@ while ($this->next()):
                                 </div>
                                 <?php if ($this->user->hasLogin()): ?>
                                     <div class="d-none d-sm-block d-md-block d-lg-block d-xl-block">
-                                        <a href="<?php echo $this->options->siteUrl . __TYPECHO_ADMIN_DIR__ . 'write-post.php?cid=' . $this->cid; ?>" class="float-right edit-link">
+                                        <a href="<?php echo $this->options->adminUrl() . 'write-post.php?cid=' . $this->cid; ?>" class="float-right edit-link">
                                             <i class="icon-pencil mr-1"></i>
                                             <b><?php echo $GLOBALS['t']['post']['edit']; ?></b>
                                         </a>
@@ -114,7 +114,7 @@ while ($this->next()):
                             </div>
                             <?php if ($this->user->hasLogin()): ?>
                                 <div class="d-none d-sm-block d-md-block d-lg-block d-xl-block">
-                                    <a href="<?php echo $this->options->siteUrl . __TYPECHO_ADMIN_DIR__ . 'write-post.php?cid=' . $this->cid; ?>" class="float-right edit-link">
+                                    <a href="<?php echo $this->options->adminUrl() . 'write-post.php?cid=' . $this->cid; ?>" class="float-right edit-link">
                                         <i class="icon-pencil mr-1"></i>
                                         <b><?php echo $GLOBALS['t']['post']['edit']; ?></b>
                                     </a>
@@ -139,7 +139,7 @@ while ($this->next()):
                         </div>
                         <?php if ($this->user->hasLogin()): ?>
                             <div class="d-none d-sm-block d-md-block d-lg-block d-xl-block">
-                                <a href="<?php echo $this->options->siteUrl . __TYPECHO_ADMIN_DIR__ . 'write-post.php?cid=' . $this->cid; ?>" class="float-right edit-link">
+                                <a href="<?php echo $this->options->adminUrl() . 'write-post.php?cid=' . $this->cid; ?>" class="float-right edit-link">
                                     <i class="icon-pencil mr-1"></i>
                                     <b><?php echo $GLOBALS['t']['post']['edit']; ?></b>
                                 </a>

--- a/inc/theme-config.php
+++ b/inc/theme-config.php
@@ -57,7 +57,7 @@ EOT;
     $form->addInput(new Typecho_Widget_Helper_Form_Element_Radio('breadcrumb', array(
         'on' => '开启',
         'off' => '关闭'
-    ), 'off', _t('面包屑导航'), _t('开启后会在导航栏下方显示路劲导航。')));
+    ), 'off', _t('面包屑导航'), _t('开启后会在导航栏下方显示路径导航。')));
 
     // 自定义导航栏链接
     $form->addInput(new Typecho_Widget_Helper_Form_Element_Textarea('navLinks', null, null, _t('自定义导航栏链接'), _t('您可以在导航栏添加自定义链接，链接的名称和 URL 都可以自定义，导航栏链接需要使用 JSON 配置 <a href="https://facile.misterma.com/%E4%B8%BB%E9%A2%98%E8%AE%BE%E7%BD%AE.html#%E8%BF%9B%E5%85%A5%E4%B8%BB%E9%A2%98%E8%AE%BE%E7%BD%AE" target="_blank">点击查看配置说明</a>。')));

--- a/inc/theme-config.php
+++ b/inc/theme-config.php
@@ -78,7 +78,7 @@ EOT;
     $form->addInput(new Typecho_Widget_Helper_Form_Element_Radio('loginLink', array(
         'show' => '显示',
         'hide' => '隐藏'
-    ), 'show', _t('登录入口'), _t('隐藏登录入口后在前台就不会显示登录入口，只能通过 域名/admin/login.php 进入登录页面')));
+    ), 'show', _t('登录入口'), _t('隐藏登录入口后在前台就不会显示登录入口，只能通过 域名' . __TYPECHO_ADMIN_DIR__ . 'login.php 进入登录页面')));
 
     //  侧边栏博客信息博主头像地址
     $form->addInput(new Typecho_Widget_Helper_Form_Element_Text('avatarUrl', null, null, _t('博主头像地址'), _t('博主头像会显示在侧边栏的博客信息区域，如果省略会使用管理员的 Gravatar 头像。')));

--- a/page.php
+++ b/page.php
@@ -51,7 +51,7 @@ $this->need('components/header.php');
                         <?php if ($this->user->hasLogin()): ?>
                             <span class="ml-2">
                         <i class="icon-pencil mr-2" aria-hidden="true"></i>
-                        <a href="<?php echo $this->options->siteUrl . 'admin/write-page.php?cid=' . $this->cid; ?>"><?php echo $GLOBALS['t']['post']['edit']; ?></a>
+                        <a href="<?php echo $this->options->siteUrl . __TYPECHO_ADMIN_DIR__ . 'write-page.php?cid=' . $this->cid; ?>"><?php echo $GLOBALS['t']['post']['edit']; ?></a>
                     </span>
                         <?php endif; ?>
                     </div>

--- a/page.php
+++ b/page.php
@@ -51,7 +51,7 @@ $this->need('components/header.php');
                         <?php if ($this->user->hasLogin()): ?>
                             <span class="ml-2">
                         <i class="icon-pencil mr-2" aria-hidden="true"></i>
-                        <a href="<?php echo $this->options->siteUrl . __TYPECHO_ADMIN_DIR__ . 'write-page.php?cid=' . $this->cid; ?>"><?php echo $GLOBALS['t']['post']['edit']; ?></a>
+                        <a href="<?php echo $this->options->adminUrl() . 'write-page.php?cid=' . $this->cid; ?>"><?php echo $GLOBALS['t']['post']['edit']; ?></a>
                     </span>
                         <?php endif; ?>
                     </div>

--- a/post.php
+++ b/post.php
@@ -73,7 +73,7 @@ $this->need('components/header.php');
                         <?php if ($this->user->hasLogin()): ?>
                         <span class="ml-2">
                             <i class="icon-pencil mr-2" aria-hidden="true"></i>
-                            <a href="<?php echo $this->options->siteUrl . 'admin/write-post.php?cid=' . $this->cid; ?>"><?php echo $GLOBALS['t']['post']['edit']; ?></a>
+                            <a href="<?php echo $this->options->siteUrl . __TYPECHO_ADMIN_DIR__ . 'write-post.php?cid=' . $this->cid; ?>"><?php echo $GLOBALS['t']['post']['edit']; ?></a>
                         </span>
                         <?php endif; ?>
                     </div>

--- a/post.php
+++ b/post.php
@@ -73,7 +73,7 @@ $this->need('components/header.php');
                         <?php if ($this->user->hasLogin()): ?>
                         <span class="ml-2">
                             <i class="icon-pencil mr-2" aria-hidden="true"></i>
-                            <a href="<?php echo $this->options->siteUrl . __TYPECHO_ADMIN_DIR__ . 'write-post.php?cid=' . $this->cid; ?>"><?php echo $GLOBALS['t']['post']['edit']; ?></a>
+                            <a href="<?php echo $this->options->adminUrl() . 'write-post.php?cid=' . $this->cid; ?>"><?php echo $GLOBALS['t']['post']['edit']; ?></a>
                         </span>
                         <?php endif; ?>
                     </div>


### PR DESCRIPTION
## 问题

在登录状态下，我尝试在博客的文章中直接点击 “编辑” 按钮，想要跳转到后台的编辑页面。

我为了安全，修改了后台的地址，所以并没有正确跳转到我的后台编辑页面，而是直接跳转到了 `/admin` 。

## 这个 PR 做了什么

在 typecho 目录的 `config.inc.php` 文件中有一个常量 `__TYPECHO_ADMIN_DIR__`  ，用于记录后台的目录。

这个 PR 是简单地将硬编码的 `/admin` 字符串修改为 `__TYPECHO_ADMIN_DIR__` 。我在我的博客上部署了，可以正确跳转到我的后台地址。 ~~但是我是PHP新手，且这是第一次修改typecho主题，所以并不知道有没有别的更优雅的实现。如果有，烦请赐教。~~

***

编辑：换成使用 `$this->options->adminUrl()` 而非 `__TYPECHO_ADMIN_DIR__` ，后者会出现只能进入后台地址而无法进入正确文章的编辑页面的问题。